### PR TITLE
Add check for string zero.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ language: php
 sudo: false
 
 php:
-  - 5.3
   - 5.4
   - 5.5
   - 5.6

--- a/classes/Kohana/Jam/Field/Price.php
+++ b/classes/Kohana/Jam/Field/Price.php
@@ -50,7 +50,7 @@ class Kohana_Jam_Field_Price extends Jam_Field_String {
 		$value = $this->run_filters($model, $value);
 
 		// Convert empty values to NULL, if needed
-		if ($this->convert_empty AND empty($value) AND $value !== 0 AND $value !== 0.0)
+		if ($this->convert_empty AND empty($value) AND $value !== 0 AND $value !== 0.0 AND $value !== '0')
 		{
 			$value  = $this->empty_value;
 			$return = TRUE;

--- a/classes/Kohana/Jam/Field/Price.php
+++ b/classes/Kohana/Jam/Field/Price.php
@@ -39,18 +39,21 @@ class Kohana_Jam_Field_Price extends Jam_Field_String {
 
 	/**
 	 * Preserve nulls and 0 / 0.0 values
-	 * @param  Jam_Validated $model 
-	 * @param  mixed        $value 
-	 * @return array               
+	 * @param  Jam_Validated $model
+	 * @param  mixed        $value
+	 * @return array
 	 */
 	protected function _default(Jam_Validated $model, $value)
 	{
 		$return = FALSE;
 
 		$value = $this->run_filters($model, $value);
+        if (is_string($value)) {
+            $value = (float) $value;
+        }
 
 		// Convert empty values to NULL, if needed
-		if ($this->convert_empty AND empty($value) AND $value !== 0 AND $value !== 0.0 AND $value !== '0')
+		if ($this->convert_empty AND empty($value) AND $value !== 0 AND $value !== 0.0)
 		{
 			$value  = $this->empty_value;
 			$return = TRUE;
@@ -72,11 +75,11 @@ class Kohana_Jam_Field_Price extends Jam_Field_String {
 	}
 
 	/**
-	 * convert to Jam_Price if not NULL 
-	 * @param  Jam_Validated $model     
-	 * @param  mixed        $value     
-	 * @param  boolean        $is_loaded 
-	 * @return Jam_Price                   
+	 * convert to Jam_Price if not NULL
+	 * @param  Jam_Validated $model
+	 * @param  mixed        $value
+	 * @param  boolean        $is_loaded
+	 * @return Jam_Price
 	 */
 	public function get(Jam_Validated $model, $value, $is_loaded)
 	{
@@ -84,9 +87,9 @@ class Kohana_Jam_Field_Price extends Jam_Field_String {
 		{
 			$value = new Jam_Price($value, $this->default_currency, $this->monetary(), $this->default_display_currency, $this->default_ceil_on_convert);
 
-			foreach (static::$autoload_from_model as $autoload_method) 
+			foreach (static::$autoload_from_model as $autoload_method)
 			{
-				if (method_exists($model, $autoload_method)) 
+				if (method_exists($model, $autoload_method))
 				{
 					$value->$autoload_method($model->$autoload_method());
 				}

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
 		}
 	],
 	"require": {
-		"php": ">=5.3.0",
+		"php": ">=5.4.0",
 		"composer/installers": "*",
 		"openbuildings/monetary": "~0.4.1"
 	},


### PR DESCRIPTION
After trim filter execution, when the value is equal to float or integer zero, then it becomes string zero. Because of that, we need also to check for string zero on default conversion.