### PR TITLE
Fix price field default string conversation

### DIFF
--- a/classes/Kohana/Jam/Field/Price.php
+++ b/classes/Kohana/Jam/Field/Price.php
@@ -48,9 +48,9 @@ class Kohana_Jam_Field_Price extends Jam_Field_String {
 		$return = FALSE;
 
 		$value = $this->run_filters($model, $value);
-        if (is_string($value)) {
-            $value = (float) $value;
-        }
+		if ((is_string($value) AND is_numeric($value)) OR is_int($value) ) {
+			$value = (float) $value;
+		}
 
 		// Convert empty values to NULL, if needed
 		if ($this->convert_empty AND empty($value) AND $value !== 0 AND $value !== 0.0)

--- a/classes/Kohana/Jam/Field/Price.php
+++ b/classes/Kohana/Jam/Field/Price.php
@@ -38,7 +38,7 @@ class Kohana_Jam_Field_Price extends Jam_Field_String {
 	}
 
 	/**
-	 * Preserve nulls and 0 / 0.0 values
+	 * Preserve nulls and 0 / 0.0 / '0' / '0.0' values
 	 * @param  Jam_Validated $model
 	 * @param  mixed        $value
 	 * @return array
@@ -53,7 +53,7 @@ class Kohana_Jam_Field_Price extends Jam_Field_String {
 		}
 
 		// Convert empty values to NULL, if needed
-		if ($this->convert_empty AND empty($value) AND $value !== 0 AND $value !== 0.0)
+		if ($this->convert_empty AND empty($value) AND $value !== 0.0)
 		{
 			$value  = $this->empty_value;
 			$return = TRUE;

--- a/tests/tests/Jam/Field/PriceTest.php
+++ b/tests/tests/Jam/Field/PriceTest.php
@@ -70,6 +70,7 @@ class Jam_Field_PriceTest extends Testcase_Monetary {
 			array(1, 1.0),
 			array(1.11, 1.11),
 			array('0', 0.0),
+			array('0.0', 0.0),
 			array('1', 1.0),
 			array('1.11', 1.11),
 			array('-1.11', -1.11),

--- a/tests/tests/Jam/Field/PriceTest.php
+++ b/tests/tests/Jam/Field/PriceTest.php
@@ -61,4 +61,40 @@ class Jam_Field_PriceTest extends Testcase_Monetary {
 
 		$this->assertSame(OpenBuildings\Monetary\Monetary::instance(), $price->monetary());
 	}
+
+
+	public function data_set()
+	{
+		return array(
+			array(0, 0.0),
+			array(1, 1.0),
+			array(1.11, 1.11),
+			array('0', 0.0),
+			array('1', 1.0),
+			array('1.11', 1.11),
+			array('-1.11', -1.11),
+			array(true, true),
+			array('', null),
+			array(null, null),
+			array(false, null),
+			array(array(), null),
+			array('', '', false),
+			array(null, null, false),
+			array(false, false, false),
+			array(array(), array(), false),
+		);
+	}
+
+	/**
+	 * @dataProvider data_set
+	 */
+
+	public function test_set($price, $expected, $convert_empty = true)
+	{
+		$product = Jam::build('product');
+		$jamPriceField = new Kohana_Jam_Field_Price();
+		$jamPriceField->convert_empty = $convert_empty;
+		$this->assertSame($expected, $jamPriceField->set($product, $price, false));
+
+	}
 }


### PR DESCRIPTION
If $value is empty string it will be converted to 0.0 
In  case  when price filter is `trim` it will convert `null` to empty string and after this to `0.0` which is wrong behavior.